### PR TITLE
Fix: Correct 'Katkı Rehberi' Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # pg-gelistirici
 Türkçe PostgreSQL Yönetici Dokümantasyonu
 
-Nasıl katkı yapılır? --> [Katkı Rehberi](/contribution.md)
+Nasıl katkı yapılır? --> [Katkı Rehberi](/katki.md)


### PR DESCRIPTION
Updated the 'Katkı Rehberi' hyperlink in the README.md file to point to the correct URL. This change resolves the issue where the previous link was directing users to an incorrect or non-existent page. #13 